### PR TITLE
mbox: include mail in ctime(3) format

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -322,6 +322,14 @@ class Message(models.Model):
     def get_age(self):
         return self._get_age(self.date)
 
+    def get_asctime(self):
+        d = self.date
+        wday = d.weekday()+1;
+        return '%s %s %d %d:%02d:%02d %s' % (
+                "MonTueWedThuFriSatSun"[wday*3-3:wday*3],
+                "JanFebMarAprMayJunJulAugSepOctNovDec"[d.month*3-3:d.month*3],
+                d.day, d.hour, d.minute, d.second, d.year)
+
     def get_last_reply_age(self):
         return self._get_age(self.last_reply_date)
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -42,5 +42,19 @@ class ProjectTest(PatchewTestCase):
         age = message.get_age()
         self.assertEqual(age, "1 day")
 
+    def test_asctime(self):
+        from api.models import Message
+        message = Message()
+        dt = datetime.datetime(2016, 10, 22, 10, 16, 40)
+        message.date = dt
+        asctime = message.get_asctime()
+        self.assertEqual(asctime, "Sat Oct 22 10:16:40 2016")
+
+        message = Message()
+        dt = datetime.datetime(2016, 10, 22, 9, 6, 4)
+        message.date = dt
+        asctime = message.get_asctime()
+        self.assertEqual(asctime, "Sat Oct 22 9:06:04 2016")
+
 if __name__ == '__main__':
     main()

--- a/www/views.py
+++ b/www/views.py
@@ -196,7 +196,7 @@ def view_series_mbox(request, project, message_id):
     if not s:
         raise Http404("Series not found")
     r = prepare_series(request, s)
-    mbox = "\n".join(["From %s %s\n" % (x.get_sender_addr(), x.date) + \
+    mbox = "\n".join(["From %s %s\n" % (x.get_sender_addr(), x.get_asctime()) + \
                       x.get_mbox() for x in r])
     return HttpResponse(mbox, content_type="text/plain")
 


### PR DESCRIPTION
RFC4155 says that the time field of mbox files should be in the format
produced by the standard C library functions ctime and asctime, for
example "Sat Oct 22 10:16:40 2016".

datetime's strftime method can produce this same format, but the month
and weekday are localized.  Because Python does not have either locale
objects or thread-local locales, add a new hand coded get_asctime()
method to do this.

Signed-off-by: Paolo Bonzini <pbonzini@redhat.com>