### PR TITLE
cli: Fix crash on "More than one series matches" message

### DIFF
--- a/patchew-cli
+++ b/patchew-cli
@@ -757,7 +757,7 @@ class ApplyCommand(SubCommand):
         if len(r) > 1 and not args.any:
             print("More than one series matched:")
             for p in r:
-                print(r["project"], r["subject"])
+                print(p["project"], p["subject"])
             return 1
         if not r[0]["is_complete"]:
             print("Series not complete")


### PR DESCRIPTION
Fix the following crash:

  $ patchew-cli apply -s has_dynamic_sysbus list
  More than one series matched:
  Traceback (most recent call last):
    File "/home/ehabkost/rh/proj/patchew/patchew-cli", line 837, in <module>
      sys.exit(main())
    File "/home/ehabkost/rh/proj/patchew/patchew-cli", line 832, in main
      return args.cmdobj.do(args, argv)
    File "/home/ehabkost/rh/proj/patchew/patchew-cli", line 760, in do
      print(r["project"], r["subject"])
  TypeError: list indices must be integers or slices, not str

Signed-off-by: Eduardo Habkost <ehabkost@redhat.com>