### PR TITLE
Introduce page headings

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -42,6 +42,14 @@ textarea {
     padding: 3px 3px 5px 3px;
 }
 
+.breadcrumb {
+    margin-bottom: 0px;
+}
+
+h1, h2, h3, .h1, .h2, .h3 {
+    margin-top: 15px;
+}
+
 .navbar-default .navbar-nav > .open > a, .navbar-default .navbar-nav > .open > a:focus, .navbar-default .navbar-nav > .open > a:hover {
     background: none;
 }

--- a/static/css/project-detail.css
+++ b/static/css/project-detail.css
@@ -1,0 +1,3 @@
+.project-description {
+	margin-bottom: 1em;
+}

--- a/static/css/series-detail.css
+++ b/static/css/series-detail.css
@@ -1,13 +1,14 @@
-.message {
-    margin-bottom: 5px;
+.series-header-info {
+    padding-bottom: 1em;
 }
 
-.message-age {
-    text-align: right;
-}
-
-.message-age > .message-author {
+.message-author, .series-header-info .message-age {
     font-weight: bold;
+}
+
+.message-info {
+    margin: 0.25em 0em;
+    font-size: 90%;
 }
 
 .reply-lvl-0 {

--- a/www/templates/project-detail.html
+++ b/www/templates/project-detail.html
@@ -1,11 +1,15 @@
 {% extends 'base.html' %}
 
 {% block header %}
+<link rel="stylesheet" href="/static/css/project-detail.css">
 {% endblock %}
 
 {% block content %}
 
 <div id="top"></div>
+<div class="col-lg-12">
+<h2>{% if project.logo %}<img alt="Project Logo" src="{{ project.logo.url }}" style="float: right"/></li>{% endif %}{{ project.name }}</h2>
+{% if project.description %}<div class="project-description">{{ project.description }}</div>{% endif %}
 
 <div id="pre-fixed"></div>
 <div class="col-lg-2">
@@ -22,10 +26,6 @@
 </div>
 <div class="col-lg-10">
     <ul class="list-group">
-        {% if project.logo %}<li class="list-group-item"><img alt="Project Logo" src="{{ project.logo.url }}" /></li>{% endif %}
-        <li class="list-group-item">
-            Project: <strong>{{ project.name }}</strong></li>
-        {% if project.description %}<li class="list-group-item">{{ project.description }}</li>{% endif %}
         {% if project.url %}<li class="list-group-item">URL: <strong><a href="{{ project.url }}">{{ project.url }}</a></strong></li>{% endif %}
         {% if project.git %}<li class="list-group-item">Git: <strong><a href="{{ project.git }}">{{ project.git }}</a></strong></li>{% endif %}
         <li class="list-group-item">Total series: <a href="{% url "series_list" project=project %}">{{ project.total_series_count }}</a></li>

--- a/www/templates/series-detail.html
+++ b/www/templates/series-detail.html
@@ -8,7 +8,17 @@
 
 {% block content %}
 
-<div id="top"></div>
+<div class="series-detail" id="top"></div>
+
+<div class="col-lg-12">
+<h2>{{ series.subject }}</h2>
+<div class="series-header-info">
+           Posted by <span class="message-author" title="{{ series.sender_full_name }}">
+                {{ series.sender_display_name }}
+           </span> <span class="message-age" title="{{ series.date }}">
+                  {{ series.age }} ago</span>
+</div>
+</div>
 
 <div id="pre-fixed"></div>
 <div class="col-lg-2">
@@ -26,13 +36,6 @@
 </div>
 <div class="col-lg-10">
     <ul class="list-group">
-        <li class="list-group-item">Subject: {{ series.subject }}</li>
-        <li class="list-group-item">Author:
-            <span title="{{ series.sender_full_name }}">
-                {{ series.sender_display_name }}
-            </span>
-        </li>
-        <li class="list-group-item">Date: {{ series.date }}</li>
         <li class="list-group-item">Patches: {{ series.num_patches }} / {{ series.total_patches }}</li>
         {% for header in series.extra_headers %}
         <li class="list-group-item">{{ header | safe }} </li>
@@ -70,21 +73,19 @@
     {% for msg in messages %}
         <div class="panel panel-default message reply-lvl-{{ msg.indent_level }}">
             <div class="panel-heading panel-toggler" onclick="patchew_toggler_onclick(this)">
-                <div class="row">
-                    <div class="col-md-9 panel-title">
+                    <h3 class="panel-title">
                         {{ msg.subject }}
-                    </div>
+                    </h3>
 
-                    <div class="col-md-3 message-age">
-                        <small>Posted by</small>
+                    <div class="message-info">
+                        Posted by
                         <span class="message-author" title="{{ msg.sender_full_name }}">
-                            {{ msg.sender_display_name }}</span><small>,</small>
-                        <span class="age" title="{{ msg.date }}">
+                            {{ msg.sender_display_name }}</span>
+                        <span class="message-age" title="{{ msg.date }}">
                             {{ msg.get_age }}
                         </span>
-                        <small>ago</small>
+                        ago
                     </div>
-                </div>
             </div>
             <div class="panel-body panel-toggle panel-hidden">
                 {% if msg.is_patch %}

--- a/www/templates/series-list.html
+++ b/www/templates/series-list.html
@@ -6,6 +6,14 @@
 
 {% block content %}
 
+<div id="top"></div>
+<div class="col-lg-12">
+<h2>{% if is_search %}Search results{% else %}All series{% endif %}
+{% if project is not None %}for {{ project }}{% endif %}</h2>
+{% if not is_search %}
+<p><a href="{% url "project_detail" project=project %}">More information about {{ project }}...</a></p>
+{% endif %}
+
 {% if series %}
 <table class="table table-condensed table-striped">
     <tr>
@@ -71,6 +79,7 @@
         {% endfor %}
     </ul>
 </nav>
+</div>
 
 <script type="text/javascript">
 

--- a/www/views.py
+++ b/www/views.py
@@ -28,6 +28,7 @@ def prepare_message(request, m, detailed):
     name, addr = m.get_sender()
     m.sender_full_name = "%s <%s>" % (name, addr)
     m.sender_display_name = name or addr
+    m.age = m.get_age()
     m.url = "/%s/%s" % (m.project.name, m.message_id)
     m.status_tags = []
     if m.is_series_head:

--- a/www/views.py
+++ b/www/views.py
@@ -121,7 +121,7 @@ def get_page_from_request(request):
 def prepare_navigate_list(cur, *path):
     """ each path is (view_name, kwargs, title) """
     r = [{"url": reverse("project_list"),
-          "title": "Projects"}]
+          "title": "Patchew"}]
     for it in path:
         r.append({"url": reverse(it[0], kwargs=it[1]),
                   "title": it[2]})
@@ -150,15 +150,13 @@ def render_series_list_page(request, query, search=None, project=None, keywords=
         cur = 'search "%s"' % search
         if project:
             nav_path = prepare_navigate_list(cur,
-                                             ("project_detail", {"project": project}, project),
-                                             ("series_list", {"project": project}, "Patches"))
+                                             ("series_list", {"project": project}, project))
         else:
             nav_path = prepare_navigate_list(cur)
     else:
         is_search = False
         search = "project:%s" % project
-        nav_path = prepare_navigate_list("Patches",
-                                         ("project_detail", {"project": project}, project))
+        nav_path = prepare_navigate_list(project)
     page_links = gen_page_links(query.count(), cur_page, PAGE_SIZE, params)
     return render_page(request, 'series-list.html',
                        series=prepare_series_list(request, series),
@@ -182,7 +180,7 @@ def view_project_detail(request, project):
     if not po:
         raise Http404("Project not found")
     nav_path = prepare_navigate_list("Information",
-                        ("project_detail", {"project": project}, project))
+                        ("series_list", {"project": project}, project))
     po.extra_info = []
     po.extra_headers = []
     po.extra_ops = []
@@ -222,9 +220,8 @@ def view_series_detail(request, project, message_id):
     s = api.models.Message.objects.find_series(message_id, project)
     if not s:
         raise Http404("Series not found")
-    nav_path = prepare_navigate_list(s.message_id,
-                    ("project_detail", {"project": project}, project),
-                    ("series_list", {"project": project}, "Patches"))
+    nav_path = prepare_navigate_list("View series",
+                    ("series_list", {"project": project}, project))
     search = "id:" + message_id
     ops = []
     return render_page(request, 'series-detail.html',


### PR DESCRIPTION
This is the next part in renovating patchew's look. The title for the current view is moved to an `<h2>` element on the top of the page; some elements are moved from the top-right list-group to a full-width block below the `<h2>`.