### PR TITLE
css: Add top padding to the fixed menu on the left

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -93,7 +93,7 @@ textarea {
 @media (min-width: 1200px) {
   .fixed {
     position: fixed;
-    top: 0px;
+    top: 10px;
     padding-left: 0px;
     padding-right: 35px;
   }

--- a/static/js/patchew.js
+++ b/static/js/patchew.js
@@ -23,6 +23,6 @@ function add_fixed_scroll_events()
         // add/remove the col-lg-NN attribute to the #fixed element, because
         // "position: fixed" computes the element's width according to the document's
         fixed.toggleClass('fixed ' + fixed.parent().attr('class'),
-                          $(window).scrollTop() >= pre_fixed.offset().top + pre_fixed.height());
+                          $(window).scrollTop() + 10 >= pre_fixed.offset().top + pre_fixed.height());
     })
 }


### PR DESCRIPTION
This seems to do the trick I wished when merging PR #35: let the fixed menu on the left have some padding from the screen top.