### PR TITLE
templates: Fix module generated content escape

### DIFF
--- a/mods/email.py
+++ b/mods/email.py
@@ -257,5 +257,5 @@ Email information is configured in "INI" style:
             return
         project.extra_info.append({"title": "Email notifications",
                                    "class": "info",
-                                   "content": self.build_config_html(request,
-                                                                     project)})
+                                   "content_html": self.build_config_html(request,
+                                                                          project)})

--- a/mods/git.py
+++ b/mods/git.py
@@ -107,7 +107,7 @@ class GitModule(PatchewModule):
             failed = message.get_property("git.apply-failed")
             message.extra_info.append({"title": "Git apply log",
                                        "class": 'danger' if failed else 'default',
-                                       "content": '<pre>%s</pre>' % l})
+                                       "content": l})
             git_url = message.get_property("git.url")
             git_repo = message.get_property("git.repo")
             git_tag = message.get_property("git.tag")
@@ -143,8 +143,8 @@ class GitModule(PatchewModule):
             return
         project.extra_info.append({"title": "Git configuration",
                                    "class": "info",
-                                   "content": self.build_config_html(request,
-                                                                     project)})
+                                   "content_html": self.build_config_html(request,
+                                                                          project)})
 
     def prepare_series_hook(self, request, series, response):
         po = series.project

--- a/mods/testing.py
+++ b/mods/testing.py
@@ -294,8 +294,8 @@ class TestingModule(PatchewModule):
             return
         project.extra_info.append({"title": "Testing configuration",
                                    "class": "info",
-                                   "content": self.build_config_html(request,
-                                                                     project)})
+                                   "content_html": self.build_config_html(request,
+                                                                          project)})
         ti = self._testers_info(project)
         if ti:
             project.extra_headers.append(ti)

--- a/www/templates/project-detail.html
+++ b/www/templates/project-detail.html
@@ -39,7 +39,9 @@
         <div class="panel-heading panel-toggler" onclick="patchew_toggler_onclick(this)">{{ info.title }}</div>
         <div class="panel-body panel-toggle panel-hidden" {% if info.content_url %}data-content-url="{{ info.content_url | safe }}"{% endif %}>
             {% if info.content %}
-                {{ info.content | safe }}
+                <pre>{{ info.content }}</pre>
+            {% elif info.content_html %}
+                {{ info.content_html | safe }}
             {% elif info.content_url %}
             <div class="progress">
                 <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%">

--- a/www/templates/series-detail.html
+++ b/www/templates/series-detail.html
@@ -57,7 +57,9 @@
         <div class="panel-heading panel-toggler" onclick="patchew_toggler_onclick(this)">{{ info.title }}</div>
         <div class="panel-body panel-toggle panel-hidden" {% if info.content_url %}data-content-url="{{ info.content_url | safe }}"{% endif %}>
             {% if info.content %}
-                {{ info.content | safe }}
+                <pre>{{ info.content }}</pre>
+            {% elif info.content_html %}
+                {{ info.content_html | safe }}
             {% elif info.content_url %}
             <div class="progress">
                 <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%">


### PR DESCRIPTION
This fixes the only bad "| safe" we have in the templates.