### PR TITLE
Single-patch view

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>=1.10, <2.0
+Django>=1.11, <2.0
 Pillow>=3.2.0
 Markdown>=2.6.6
 django-debug-toolbar==1.8

--- a/static/css/series-detail.css
+++ b/static/css/series-detail.css
@@ -6,6 +6,28 @@
     font-weight: bold;
 }
 
+#patches {
+    margin: 1.5em 0;
+    list-style-type: none;
+    padding: 0em 0em 0em 2em;
+    margin-left: 0.5em;
+}
+#patches > li {
+    margin: 1em 0em;
+    padding: 0em;
+}
+#patches > li.active {
+    font-weight: bold;
+}
+#patches > li .fa {
+    position: relative;
+    color: #337ab7;
+    left: -0.5em;
+    width: 1em;
+    text-align: center;
+    display: inline-block;
+}
+
 .message-info {
     margin: 0.25em 0em;
     font-size: 90%;
@@ -14,20 +36,16 @@
 .reply-lvl-0 {
 }
 .reply-lvl-1 {
-    margin-left: 8px;
+    margin-left: 0.5em;
 }
 .reply-lvl-2 {
-    margin-left: 16px;
+    margin-left: 1em;
 }
 .reply-lvl-3 {
-    margin-left: 24px;
+    margin-left: 1.5em;
 }
 .reply-lvl-4 {
-    margin-left: 32px;
-}
-
-.panel {
-    margin-bottom: 10px;
+    margin-left: 2em;
 }
 
 #series-links::before {

--- a/www/templates/series-detail.html
+++ b/www/templates/series-detail.html
@@ -115,7 +115,7 @@
 	{% if is_cover_letter and forloop.first%}
         <ul class="panel" id="patches">
           {% for patch in patches %}
-	  <li><span class="fa fa-lg fa-ellipsis-v"></span><a href="{{ patch.message_id }}/">{{ patch.subject }}</a></li>
+	  <li><span class="fa fa-lg {% if patch.has_replies %}fa-comment-o{% else %}fa-ellipsis-v{% endif %}"></span><a href="{{ patch.message_id }}/">{{ patch.subject }}</a></li>
 	  {% endfor %}
           </ul>
 	{% endif %}
@@ -126,7 +126,7 @@
     <ul class="panel" id="patches">
     {% for patch in patches %}
     <li {% if patch.message_id == message_id %}class="active"{% else %}><a href="../{{ patch.message_id }}/"{%endif%}>
-      <span class="fa fa-lg fa-ellipsis-v"></span>
+      <span class="fa fa-lg {% if patch.has_replies %}fa-comment-o{% else %}fa-ellipsis-v{% endif %}"></span>
       {{ patch.subject }}
       {% if patch.message_id != message_id %}</a>{% endif %}</li>
     {% endfor %}

--- a/www/templates/series-detail.html
+++ b/www/templates/series-detail.html
@@ -66,6 +66,12 @@
  {% endif %}
 </div>
 {% endfor %}
+
+{% if series.get_diff_stat %}
+<div class="panel-body">
+    <pre class="body-full">{{ series.get_diff_stat }}</pre>
+</div>
+{% endif %}
 </div>
 </div>
 
@@ -76,18 +82,8 @@
         <a href="#" class="list-group-item" id="btn-fold-all">Fold all</a>
     </div>
 </div>
-<div class="col-lg-10">
-    {% if series.get_diff_stat %}
-    <div class="panel panel-default">
-        <div class="panel-heading panel-toggler" onclick="patchew_toggler_onclick(this)">
-        Changeset
-        </div>
-        <div class="panel-body panel-collapse collapse in">
-            <pre class="body-full">{{ series.get_diff_stat }}</pre>
-        </div>
-    </div>
-    {% endif %}
 
+<div class="col-lg-10">
     <div id="thread">
     {% for msg in messages %}
         <div class="panel panel-default message reply-lvl-{{ msg.indent_level }}">

--- a/www/templates/series-detail.html
+++ b/www/templates/series-detail.html
@@ -13,7 +13,7 @@
 <div class="series-detail" id="top"></div>
 
 <div class="col-lg-12">
-<h2>{{ series.subject }}</h2>
+<h2>{{ subject }}</h2>
 <div class="series-header-info">
             <span class="message-author" title="{{ series.sender_full_name }}">
                 {{ series.sender_display_name }}
@@ -67,10 +67,12 @@
 </div>
 {% endfor %}
 
-{% if series.get_diff_stat %}
-<div class="panel-body">
-    <pre class="body-full">{{ series.get_diff_stat }}</pre>
-</div>
+{% if is_head %}
+    {% if series.get_diff_stat %}
+    <div class="panel-body">
+        <pre class="body-full">{{ series.get_diff_stat }}</pre>
+    </div>
+    {% endif %}
 {% endif %}
 </div>
 </div>
@@ -102,7 +104,7 @@
                         ago
                     </div>
             </div>
-            <div class="panel-body panel-collapse collapse">
+            <div class="panel-body panel-collapse collapse in">
                 {% if msg.is_patch %}
                 <pre class="body-full"><code class="diff">{{ msg.get_body }}</code></pre>
                 {% else %}
@@ -110,8 +112,26 @@
                 {% endif %}
             </div>
         </div>
+	{% if is_cover_letter and forloop.first%}
+        <ul class="panel" id="patches">
+          {% for patch in patches %}
+	  <li><span class="fa fa-lg fa-ellipsis-v"></span><a href="{{ patch.message_id }}/">{{ patch.subject }}</a></li>
+	  {% endfor %}
+          </ul>
+	{% endif %}
     {% endfor %}
     </div>
+
+    {% if not is_head %}
+    <ul class="panel" id="patches">
+    {% for patch in patches %}
+    <li {% if patch.message_id == message_id %}class="active"{% else %}><a href="../{{ patch.message_id }}/"{%endif%}>
+      <span class="fa fa-lg fa-ellipsis-v"></span>
+      {{ patch.subject }}
+      {% if patch.message_id != message_id %}</a>{% endif %}</li>
+    {% endfor %}
+    </ul>
+    {% endif %}
 </div>
 
 <script type="text/javascript">

--- a/www/urls.py
+++ b/www/urls.py
@@ -33,6 +33,7 @@ urlpatterns += [
         url(r"^(?P<project>[^/]*)/$", views.view_series_list, name="series_list"),
         url(r"^(?P<project>[^/]*)/info$", views.view_project_detail, name="project_detail"),
         url(r"^(?P<project>[^/]*)/(?P<message_id>[^/]*)/$", views.view_series_detail, name="series_detail"),
+        url(r"^(?P<project>[^/]*)/(?P<thread_id>[^/]*)/(?P<message_id>[^/]*)/$", views.view_series_message, name="series_message"),
         url(r"^(?P<project>[^/]*)/(?P<message_id>[^/]*)/mbox$", views.view_series_mbox),
         url(r"^$", views.view_project_list, name="project_list"),
         ]

--- a/www/views.py
+++ b/www/views.py
@@ -12,6 +12,7 @@ import urllib.request, urllib.parse, urllib.error
 from django.shortcuts import render
 from django.template import Context
 from django.http import HttpResponse, Http404
+from django.db.models import Exists, OuterRef
 from django.urls import reverse
 from django.conf import settings
 import api
@@ -62,6 +63,8 @@ def prepare_patches(request, m, max_depth=None):
     if m.total_patches == 1:
         return []
     replies = m.get_replies().filter(is_patch=True)
+    commit_replies = api.models.Message.objects.filter(in_reply_to=OuterRef('message_id'))
+    replies = replies.annotate(has_replies=Exists(commit_replies))
     return [prepare_message(request, x, True)
             for x in replies]
 


### PR DESCRIPTION
This pull request is the remaining part of issue #22.

All message subjects are showed right after the cover letter, with links to a separate subthread view and a different icon for messages that had replies.
