### PR TITLE
.travis.yml: Drop Python 'nightly' build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - "3.5"
   - "3.5-dev" # 3.5 development branch
   - "3.6-dev" # 3.6 development branch
-  - "nightly" # currently points to 3.7-dev
 # command to install dependencies
 install: "pip install -r requirements.txt"
 # command to run tests


### PR DESCRIPTION
This was copy and paste, and is now creating false positives.