### PR TITLE
importer.docker: fix typo

### DIFF
--- a/scripts/dockerfiles/importer.docker
+++ b/scripts/dockerfiles/importer.docker
@@ -2,7 +2,7 @@ FROM fedora:latest
 RUN dnf install -y python offlineimap findutils git wget
 RUN git config --global user.email "importer@patchew.org"
 RUN git config --global user.name "Patchew Importer"
-RUN if test -f /data/patchew/identify; then \
+RUN if test -f /data/patchew/identity; then \
         echo IdentityFile=/data/patchew/identity > ~/.ssh/config; \
     else \
         ssh-keygen -t rsa -q -C patchew-importer -f ~/.ssh/id_rsa; \


### PR DESCRIPTION
check 'identity', not 'identify', in /data/patchew when configuring the
SSH agent. Not doing so caused errors when pulling github repositories
using SSH.

Signed-off-by: Davide Caratti <davide.caratti@gmail.com>