### PR TITLE
Better formatting for relative timestamps

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -817,32 +817,8 @@ class Message(models.Model):
     def get_sender_name(self):
         return self.sender[0]
 
-    def _get_age(self, date):
-        def _seconds_to_human(sec):
-            unit = "second"
-            if sec > 60:
-                sec /= 60
-                unit = "minute"
-                if sec > 60:
-                    sec /= 60
-                    unit = "hour"
-                    if sec > 24:
-                        sec /= 24
-                        unit = "day"
-                        if sec > 7:
-                            sec /= 7
-                            unit = "week"
-            if sec >= 2:
-                unit += "s"
-            return "%s %s" % (int(sec), unit)
-
-        age = int((datetime.datetime.utcnow() - date).total_seconds())
-        if age < 0:
-            return "now"
-        return _seconds_to_human(age)
-
     def get_age(self):
-        return self._get_age(self.date)
+        return self.date
 
     def get_asctime(self):
         d = self.date
@@ -858,7 +834,7 @@ class Message(models.Model):
         )
 
     def get_last_reply_age(self):
-        return self._get_age(self.last_reply_date or self.date)
+        return self.last_reply_date or self.date
 
     def get_body(self):
         return self.get_mbox_obj().get_body()

--- a/api/models.py
+++ b/api/models.py
@@ -817,9 +817,6 @@ class Message(models.Model):
     def get_sender_name(self):
         return self.sender[0]
 
-    def get_age(self):
-        return self.date
-
     def get_asctime(self):
         d = self.date
         wday = d.weekday() + 1

--- a/api/models.py
+++ b/api/models.py
@@ -830,7 +830,7 @@ class Message(models.Model):
             d.year,
         )
 
-    def get_last_reply_age(self):
+    def get_last_reply_date(self):
         return self.last_reply_date or self.date
 
     def get_body(self):

--- a/patchew/settings.py
+++ b/patchew/settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.humanize",
     "rest_auth",
     "rest_framework",
     "rest_framework.authtoken",

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -22,26 +22,6 @@ class MessageTest(PatchewTestCase):
         self.create_superuser()
         self.p = self.add_project("QEMU", "qemu-devel@nongnu.org")
 
-    def test_0_second(self):
-        message = Message()
-        message.date = datetime.datetime.utcnow()
-        age = message.get_age()
-        self.assertEqual(age, "0 second")
-
-    def test_now(self):
-        message = Message()
-        dt = datetime.datetime.fromtimestamp(time.time() + 100)
-        message.date = dt
-        age = message.get_age()
-        self.assertEqual(age, "now")
-
-    def test_1_day(self):
-        message = Message()
-        dt = datetime.datetime.fromtimestamp(time.time() - 3600 * 25)
-        message.date = dt
-        age = message.get_age()
-        self.assertEqual(age, "1 day")
-
     def test_asctime(self):
         message = Message()
         dt = datetime.datetime(2016, 10, 22, 10, 16, 40)

--- a/www/templates/series-detail.html
+++ b/www/templates/series-detail.html
@@ -24,7 +24,7 @@
                 {{ series.total_patches }}
                 patch{{ series.total_patches|pluralize:"es" }}
             </span> <span class="message-age" title="{{ series.date }}">
-                {{ series.age|naturaltime }}</span>
+                {{ series.date|naturaltime }}</span>
   {% if series.extra_links %}
   <ul id="series-links">
     {% for op in series.extra_links %}

--- a/www/templates/series-detail.html
+++ b/www/templates/series-detail.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load humanize %}
 
 {% block header %}
 <link rel="stylesheet" href="/static/css/series-detail.css">
@@ -19,11 +20,11 @@
 <div class="series-header-info">
             <span class="message-author" title="{{ series.sender_full_name }}">
                 {{ series.sender_display_name }}
-	    </span> posted <span class="patch-count">
-		    {{ series.total_patches }}
-		    patch{% if series.total_patches != 1 %}es{% endif %}
-	    </span> <span class="message-age" title="{{ series.date }}">
-		    {{ series.age }} ago</span>
+            </span> posted <span class="patch-count">
+                {{ series.total_patches }}
+                patch{{ series.total_patches|pluralize:"es" }}
+            </span> <span class="message-age" title="{{ series.date }}">
+                {{ series.age|naturaltime }}</span>
   {% if series.extra_links %}
   <ul id="series-links">
     {% for op in series.extra_links %}
@@ -130,9 +131,8 @@ function prompt_and_open(obj, url) {
                         <span class="message-author" title="{{ msg.sender_full_name }}">
                             {{ msg.sender_display_name }}</span>
                         <span class="message-age" title="{{ msg.date }}">
-                            {{ msg.get_age }}
+                            {{ msg.get_age|naturaltime }}
                         </span>
-                        ago
                     </div>
             </div>
             <div class="panel-body panel-collapse collapse in">

--- a/www/templates/series-detail.html
+++ b/www/templates/series-detail.html
@@ -131,7 +131,7 @@ function prompt_and_open(obj, url) {
                         <span class="message-author" title="{{ msg.sender_full_name }}">
                             {{ msg.sender_display_name }}</span>
                         <span class="message-age" title="{{ msg.date }}">
-                            {{ msg.get_age|naturaltime }}
+                            {{ msg.date|naturaltime }}
                         </span>
                     </div>
             </div>

--- a/www/templates/series-list.html
+++ b/www/templates/series-list.html
@@ -62,7 +62,7 @@
             {% if order_by_reply %}
             <td><span class="timestamp" title="{{ s.last_reply_date }}">{{ s.get_last_reply_age|naturaltime }}</span></td>
             {% else %}
-            <td><span class="timestamp" title="{{ s.date }}">{{ s.get_age|naturaltime }}</span></td>
+            <td><span class="timestamp" title="{{ s.date }}">{{ s.date|naturaltime }}</span></td>
             {% endif %}
         </tr>
     {% endfor %}

--- a/www/templates/series-list.html
+++ b/www/templates/series-list.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load humanize %}
 
 {% block header %}
 <link rel="stylesheet" href="/static/css/series-list.css">
@@ -59,9 +60,9 @@
                 </span>
             </td>
             {% if order_by_reply %}
-            <td><span class="timestamp" title="{{ s.last_reply_date }}">{{ s.get_last_reply_age }}</span></td>
+            <td><span class="timestamp" title="{{ s.last_reply_date }}">{{ s.get_last_reply_age|naturaltime }}</span></td>
             {% else %}
-            <td><span class="timestamp" title="{{ s.date }}">{{ s.get_age }}</span></td>
+            <td><span class="timestamp" title="{{ s.date }}">{{ s.get_age|naturaltime }}</span></td>
             {% endif %}
         </tr>
     {% endfor %}

--- a/www/templates/series-list.html
+++ b/www/templates/series-list.html
@@ -60,7 +60,7 @@
                 </span>
             </td>
             {% if order_by_reply %}
-            <td><span class="timestamp" title="{{ s.last_reply_date }}">{{ s.get_last_reply_age|naturaltime }}</span></td>
+            <td><span class="timestamp" title="{{ s.get_last_reply_date }}">{{ s.get_last_reply_date|naturaltime }}</span></td>
             {% else %}
             <td><span class="timestamp" title="{{ s.date }}">{{ s.date|naturaltime }}</span></td>
             {% endif %}

--- a/www/views.py
+++ b/www/views.py
@@ -42,7 +42,6 @@ def prepare_message(request, project, m, detailed):
     name, addr = m.sender
     m.sender_full_name = "%s <%s>" % (name, addr)
     m.sender_display_name = name or addr
-    m.age = m.date
     m.url = reverse(
         "series_detail", kwargs={"project": project.name, "message_id": m.message_id}
     )

--- a/www/views.py
+++ b/www/views.py
@@ -42,7 +42,7 @@ def prepare_message(request, project, m, detailed):
     name, addr = m.sender
     m.sender_full_name = "%s <%s>" % (name, addr)
     m.sender_display_name = name or addr
-    m.age = m.get_age()
+    m.age = m.date
     m.url = reverse(
         "series_detail", kwargs={"project": project.name, "message_id": m.message_id}
     )


### PR DESCRIPTION
* Uses Django's naturaltime filter, no extra dependencies,
* Avoid showing `now ago` in the series details page,
* Uses months/years as measurement units, much easier to understand than
  the number of elapsed weeks.