### PR TITLE
git: option not to update series on tags

### DIFF
--- a/mods/git.py
+++ b/mods/git.py
@@ -87,6 +87,12 @@ class GitModule(PatchewModule):
                 desc="Publicly visible URL template for applied branch, where %t will be replaced by the applied tag name",
                 required=True,
             ),
+            schema.BooleanSchema(
+                "update_series_on_tags",
+                "Update series on new tags",
+                desc="Whether series are pushed (overriden) when new tags are sent on the mailing list, on by default",
+                default=True,
+            ),
         ],
     )
 
@@ -109,7 +115,10 @@ class GitModule(PatchewModule):
         r.save()
 
     def on_tags_update(self, event, series, **params):
-        if series.is_complete:
+        config = self.get_project_config(series.project)
+        update_series_on_tags = config.get("update_series_on_tags", True)
+
+        if update_series_on_tags and series.is_complete:
             self.mark_as_pending_apply(
                 series,
                 {

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -257,5 +257,17 @@ class GitTest(PatchewTestCase):
         out, err = self.do_apply(True)
         self.assertIn("ci.skip", out)
 
+    def test_no_update_series_on_tags(self):
+        # No need to test the opposite (default value), implicitly tested before
+        self.p.config["git"]["update_series_on_tags"] = False
+        self.p.save()
+        self.cli_import("0013-foo-patch.mbox.gz")
+        self.do_apply(True)
+
+        # Getting a new reviewed-by shouldn't trigger re-push
+        self.cli_import("0025-foo-patch-review.mbox.gz")
+        out, err = self.do_apply(True)
+        self.assertIn("No series need apply", out)
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Currently, when a new tag is sent on the mailing list, the series is updated in the Git repository.

The push is done with '-o ci.skip', but this seems to be something specific to GitLab. It has no effects with GitHub for example. Not to waste resources on retesting everything and sending notifications once a tag is shared, a new per-project option has been added:

    update_series_on_tags

Not to change the current behaviour, series will continue to be updated on new tags by default, except if this option is explicitly disabled.